### PR TITLE
Clean $srcdir before running prepare()

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -1220,9 +1220,9 @@ MakePkgs() {
             # extraction, prepare and pkgver update
             Note "i" $"Preparing ${colorW}${pkgsdeps[$i]}${reset}..."
             if [[ "$silent" = true ]]; then
-                makepkg -od --skipinteg "${makeopts[@]}" &>/dev/null
+                makepkg -Cod --skipinteg "${makeopts[@]}" &>/dev/null
             else
-                makepkg -od --skipinteg "${makeopts[@]}"
+                makepkg -Cod --skipinteg "${makeopts[@]}"
             fi
             (($? > 0)) && errmakepkg+=("${pkgsdeps[$i]}")
         fi


### PR DESCRIPTION
This resolves an issue where, when running prepare twice, files created
by patches make patching – and with that, building – fail.