### PR TITLE
Imply --needed for --devel

### DIFF
--- a/pacaur
+++ b/pacaur
@@ -132,6 +132,7 @@ UpgradeAur() {
 
     # add devel packages
     if ((devel)); then
+        needed=1
         for i in "${allaurpkgs[@]}"; do
             [[ "${i}" != *${vcs} || " ${aurpkgs[*]} " = *" ${i} "* ]] || aurpkgs+=("${i}")
         done


### PR DESCRIPTION
--devel pulls in a list of potential devel packages to consider, while
--needed then filters out the ones that don't actually need to upgrade.

Given that I've never actually seen --devel used without --needed. It
makes sense to just make the former imply the latter and simplify the
user command.